### PR TITLE
Wrong snippet

### DIFF
--- a/lessons/3d-basic-rendering/perspective-and-orthographic-projection-matrix/opengl-perspective-projection-matrix.md
+++ b/lessons/3d-basic-rendering/perspective-and-orthographic-projection-matrix/opengl-perspective-projection-matrix.md
@@ -248,7 +248,7 @@ aspect\;ratio = \dfrac{width}{height}\\
 top = \tan( \dfrac{ FOV } {2}) * near\\
 bottom = -top \\
 right = top * aspect\;ratio\\
-left = bottom = -top * aspect\;ratio
+left = -top * aspect\;ratio
 \end{array}
 $$
 


### PR DESCRIPTION
In the secion for non-square camera the `bottom` was shown twice. I've removed the wrong (i think) occurence.